### PR TITLE
added more robust fix to prefixing space issue

### DIFF
--- a/unitconversion.py
+++ b/unitconversion.py
@@ -9,7 +9,6 @@ from abc import abstractmethod
 from math import log10, floor
 
 END_NUMBER_REGEX = re.compile("(^|\s)(-|−)?[0-9]+([\,\.][0-9]+)?\s+$")
-SPACE_PREFIXED_REGEX = re.compile("^ \d*[ ]?$")
 REMOVE_REGEX = re.compile("((´|`)+[^>]+(´|`)+)")
 
 UNICODEMINUS = True    # Option: Should UNICODE minus symbol '−' be converted to a standard dash '-'?
@@ -92,13 +91,17 @@ class NormalUnit( Unit ):
         for find in iterator:
             numberResult = END_NUMBER_REGEX.search( originalText[ 0 : find.start() ] )
             if numberResult is not None:
-                isSpacePrefixed = SPACE_PREFIXED_REGEX.search( numberResult.group() )
+                initialSpaceCount = 0
+                prefix = ""
+                while (numberResult.group()[initialSpaceCount].isspace()):
+                    prefix += numberResult.group()[initialSpaceCount]
+                    initialSpaceCount += 1
                 metricValue = self.toMetric( float( numberResult.group().replace(",", ".") ) )
                 if metricValue is None:
                     continue
                 repl = {}
                 repl[ "start" ] = numberResult.start()
-                repl[ "text"  ] = (" " if isSpacePrefixed else "") + metricValue
+                repl[ "text"  ] = (prefix) + metricValue
                 repl[ "end" ] = find.end()
                 replacements.append(repl)
         if len(replacements)>0:


### PR DESCRIPTION
https://github.com/Wendelstein7/DiscordUnitCorrector/issues/18 was marked as closed, but the bug has only been fixed when the number in question is an integer. This pull request should make the following improvements to the robustness of the fix (additional third-party testing to confirm this is, of course, desirable):
 - decimal numbers now get their prefixed spaces restored
 - supports space characters with codes other than 32 (e.g, half space)
 - supports multiple prefixed spaces (not used in current context)
 
